### PR TITLE
Apply filters to the course fullname

### DIFF
--- a/block_common_courses.php
+++ b/block_common_courses.php
@@ -74,7 +74,7 @@ class block_common_courses extends block_list {
             foreach ($commoncourses as $common) {
                 $coursevisibility = $common->visible;
                 if ($coursevisibility == 1) {
-                    $coursename = $common->fullname;
+                    $coursename = format_string($common->fullname);
                     $course = $common->id;
                     if ($course != $courseid) {
                         $url = './view.php?id='.$hisuserid.'&course='.$common->id;


### PR DESCRIPTION
When there are filters enabled on the site applied to content and headings (such as Multi-Language Content filters), you have to use the format_string function to apply them [1]. 

Here I've added a call to that function to the $coursename and that fixes it.

[1]: https://docs.moodle.org/dev/Filters#Trying_out_your_filter